### PR TITLE
Pass SqlBulkCopyOptions to SqlBulkCopy

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -264,16 +264,15 @@ function Write-DbaDataTable {
 			return
 		}
 
-		$bulkCopyOptions = @()
+		$bulkCopyOptions = 0
 		$options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default", "Truncate"
 
 		foreach ($option in $options) {
 			$optionValue = Get-Variable $option -ValueOnly -ErrorAction SilentlyContinue
 			if ($optionValue -eq $true) {
-				$bulkCopyOptions += "$option"
+				$bulkCopyOptions += $([Data.SqlClient.SqlBulkCopyOptions]::$option).value__
 			}
 		}
-		$bulkCopyOptions = $bulkCopyOptions -join " & "
 
 		if ($truncate -eq $true) {
 			if ($Pscmdlet.ShouldProcess($SqlInstance, "Truncating $fqtn")) {
@@ -287,7 +286,7 @@ function Write-DbaDataTable {
 			}
 		}
 
-		$bulkCopy = New-Object Data.SqlClient.SqlBulkCopy("$($server.ConnectionContext.ConnectionString);Database=$Database")
+		$bulkCopy = New-Object Data.SqlClient.SqlBulkCopy("$($server.ConnectionContext.ConnectionString);Database=$Database", $bulkCopyOptions)
 		$bulkCopy.DestinationTableName = $fqtn
 		$bulkCopy.BatchSize = $BatchSize
 		$bulkCopy.NotifyAfter = $NotifyAfter


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Enable the use of Write-DbaDatabaseTable to fire triggers, check constraints, truncate table, etc.

### Approach
<!-- How does this change solve that purpose -->
$bulkCopyOptions are set, but never used. This change implements defaulting $bulkCopyOptions to SqlBulkCopyOptions.Default, adds enum key values to the variable, and passes the result to the SqlBulkCopy constructor.

